### PR TITLE
adapted notebook to new STAM API and remeasured things

### DIFF
--- a/programs/stam.ipynb
+++ b/programs/stam.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -65,7 +67,7 @@
     {
      "data": {
       "text/html": [
-       "<b title=\"local github\">app:</b> <span title=\"repo clone offline under /Users/me/github\">~/github/ETCBC/bhsa/app</span>"
+       "<b title=\"local github\">app:</b> <span title=\"repo clone offline under /home/proycon/github\">~/github/ETCBC/bhsa/app</span>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -77,7 +79,7 @@
     {
      "data": {
       "text/html": [
-       "<b title=\"local github\">data:</b> <span title=\"repo clone offline under /Users/me/github\">~/github/ETCBC/bhsa/tf/2021</span>"
+       "<b title=\"local github\">data:</b> <span title=\"repo clone offline under /home/proycon/github\">~/github/ETCBC/bhsa/tf/2021</span>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -89,7 +91,7 @@
     {
      "data": {
       "text/html": [
-       "<b title=\"local github\">data:</b> <span title=\"repo clone offline under /Users/me/github\">~/github/ETCBC/phono/tf/2021</span>"
+       "<b title=\"local github\">data:</b> <span title=\"repo clone offline under /home/proycon/github\">~/github/ETCBC/phono/tf/2021</span>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -101,7 +103,7 @@
     {
      "data": {
       "text/html": [
-       "<b title=\"local github\">data:</b> <span title=\"repo clone offline under /Users/me/github\">~/github/ETCBC/parallels/tf/2021</span>"
+       "<b title=\"local github\">data:</b> <span title=\"repo clone offline under /home/proycon/github\">~/github/ETCBC/parallels/tf/2021</span>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -836,7 +838,7 @@
        "    </div>\n",
        "</details>\n",
        "\n",
-       "            <b>Settings:</b><br><details ><summary><b>specified</b></summary><ol><li><b>apiVersion</b>: <code>3</code></li><li><b>appName</b>: <code>ETCBC/bhsa</code></li><li><b>appPath</b>: <code>/Users/me/github/ETCBC/bhsa/app</code></li><li><b>commit</b>: <i>no value</i></li><li><b>css</b>: <code>''</code></li><li><details><summary><b>dataDisplay</b>:</summary><ul><li><details><summary><b>exampleSectionHtml</b>:</summary><code>&lt;code>Genesis 1:1&lt;/code> (use &lt;a href=\"https://github.com/{org}/{repo}/blob/master/tf/{version}/book%40en.tf\" target=\"_blank\">English book names&lt;/a>)</code></details></li><li><details><summary><b>excludedFeatures</b>:</summary><ul><li><code>g_uvf_utf8</code></li><li><code>g_vbs</code></li><li><code>kq_hybrid</code></li><li><code>languageISO</code></li><li><code>g_nme</code></li><li><code>lex0</code></li><li><code>is_root</code></li><li><code>g_vbs_utf8</code></li><li><code>g_uvf</code></li><li><code>dist</code></li><li><code>root</code></li><li><code>suffix_person</code></li><li><code>g_vbe</code></li><li><code>dist_unit</code></li><li><code>suffix_number</code></li><li><code>distributional_parent</code></li><li><code>kq_hybrid_utf8</code></li><li><code>crossrefSET</code></li><li><code>instruction</code></li><li><code>g_prs</code></li><li><code>lexeme_count</code></li><li><code>rank_occ</code></li><li><code>g_pfm_utf8</code></li><li><code>freq_occ</code></li><li><code>crossrefLCS</code></li><li><code>functional_parent</code></li><li><code>g_pfm</code></li><li><code>g_nme_utf8</code></li><li><code>g_vbe_utf8</code></li><li><code>kind</code></li><li><code>g_prs_utf8</code></li><li><code>suffix_gender</code></li><li><code>mother_object_type</code></li></ul></details></li><li><details><summary><b>noneValues</b>:</summary><ul><li><code>absent</code></li><li><code>n/a</code></li><li><code>none</code></li><li><code>unknown</code></li><li><i>no value</i></li><li><code>NA</code></li></ul></details></li></ul></details></li><li><details><summary><b>docs</b>:</summary><ul><li><b>docBase</b>: <code>{docRoot}/{repo}</code></li><li><b>docExt</b>: <code>''</code></li><li><b>docPage</b>: <code>''</code></li><li><b>docRoot</b>: <code>https://{org}.github.io</code></li><li><b>featurePage</b>: <code>0_home</code></li></ul></details></li><li><b>interfaceDefaults</b>: <code>{}</code></li><li><b>isCompatible</b>: <code>True</code></li><li><b>local</b>: <code>clone</code></li><li><b>localDir</b>: <code>/Users/me/github/ETCBC/bhsa/_temp</code></li><li><details><summary><b>provenanceSpec</b>:</summary><ul><li><b>corpus</b>: <code>BHSA = Biblia Hebraica Stuttgartensia Amstelodamensis</code></li><li><b>doi</b>: <code>10.5281/zenodo.1007624</code></li><li><details><summary><b>moduleSpecs</b>:</summary><ul><li><details><summary>:</summary><ul><li><b>backend</b>: <i>no value</i></li><li><b>corpus</b>: <code>Phonetic Transcriptions</code></li><li><details><summary><b>docUrl</b>:</summary><code>https://nbviewer.jupyter.org/github/etcbc/phono/blob/master/programs/phono.ipynb</code></details></li><li><b>doi</b>: <code>10.5281/zenodo.1007636</code></li><li><b>org</b>: <code>ETCBC</code></li><li><b>relative</b>: <code>/tf</code></li><li><b>repo</b>: <code>phono</code></li></ul></details></li><li><details><summary>:</summary><ul><li><b>backend</b>: <i>no value</i></li><li><b>corpus</b>: <code>Parallel Passages</code></li><li><details><summary><b>docUrl</b>:</summary><code>https://nbviewer.jupyter.org/github/ETCBC/parallels/blob/master/programs/parallels.ipynb</code></details></li><li><b>doi</b>: <code>10.5281/zenodo.1007642</code></li><li><b>org</b>: <code>ETCBC</code></li><li><b>relative</b>: <code>/tf</code></li><li><b>repo</b>: <code>parallels</code></li></ul></details></li></ul></details></li><li><b>org</b>: <code>ETCBC</code></li><li><b>relative</b>: <code>/tf</code></li><li><b>repo</b>: <code>bhsa</code></li><li><b>version</b>: <code>2021</code></li><li><b>webBase</b>: <code>https://shebanq.ancient-data.org/hebrew</code></li><li><b>webHint</b>: <code>Show this on SHEBANQ</code></li><li><b>webLang</b>: <code>la</code></li><li><b>webLexId</b>: <code>True</code></li><li><details><summary><b>webUrl</b>:</summary><code>{webBase}/text?book=&lt;1>&amp;chapter=&lt;2>&amp;verse=&lt;3>&amp;version={version}&amp;mr=m&amp;qw=q&amp;tp=txt_p&amp;tr=hb&amp;wget=v&amp;qget=v&amp;nget=vt</code></details></li><li><b>webUrlLex</b>: <code>{webBase}/word?version={version}&amp;id=&lt;lid></code></li></ul></details></li><li><b>release</b>: <i>no value</i></li><li><details><summary><b>typeDisplay</b>:</summary><ul><li><details><summary><b>clause</b>:</summary><ul><li><b>label</b>: <code>{typ} {rela}</code></li><li><b>style</b>: <code>''</code></li></ul></details></li><li><details><summary><b>clause_atom</b>:</summary><ul><li><b>hidden</b>: <code>True</code></li><li><b>label</b>: <code>{code}</code></li><li><b>level</b>: <code>1</code></li><li><b>style</b>: <code>''</code></li></ul></details></li><li><details><summary><b>half_verse</b>:</summary><ul><li><b>hidden</b>: <code>True</code></li><li><b>label</b>: <code>{label}</code></li><li><b>style</b>: <code>''</code></li><li><b>verselike</b>: <code>True</code></li></ul></details></li><li><details><summary><b>lex</b>:</summary><ul><li><b>featuresBare</b>: <code>gloss</code></li><li><b>label</b>: <code>{voc_lex_utf8}</code></li><li><b>lexOcc</b>: <code>word</code></li><li><b>style</b>: <code>orig</code></li><li><b>template</b>: <code>{voc_lex_utf8}</code></li></ul></details></li><li><details><summary><b>phrase</b>:</summary><ul><li><b>label</b>: <code>{typ} {function}</code></li><li><b>style</b>: <code>''</code></li></ul></details></li><li><details><summary><b>phrase_atom</b>:</summary><ul><li><b>hidden</b>: <code>True</code></li><li><b>label</b>: <code>{typ} {rela}</code></li><li><b>level</b>: <code>1</code></li><li><b>style</b>: <code>''</code></li></ul></details></li><li><details><summary><b>sentence</b>:</summary><ul><li><b>label</b>: <code>{number}</code></li><li><b>style</b>: <code>''</code></li></ul></details></li><li><details><summary><b>sentence_atom</b>:</summary><ul><li><b>hidden</b>: <code>True</code></li><li><b>label</b>: <code>{number}</code></li><li><b>level</b>: <code>1</code></li><li><b>style</b>: <code>''</code></li></ul></details></li><li><details><summary><b>subphrase</b>:</summary><ul><li><b>hidden</b>: <code>True</code></li><li><b>label</b>: <code>{number}</code></li><li><b>style</b>: <code>''</code></li></ul></details></li><li><details><summary><b>word</b>:</summary><ul><li><b>features</b>: <code>pdp vs vt</code></li><li><b>featuresBare</b>: <code>lex:gloss</code></li></ul></details></li></ul></details></li><li><b>writing</b>: <code>hbo</code></li></ol></details>\n"
+       "            <b>Settings:</b><br><details ><summary><b>specified</b></summary><ol><li><b>apiVersion</b>: <code>3</code></li><li><b>appName</b>: <code>ETCBC/bhsa</code></li><li><b>appPath</b>: <code>/home/proycon/github/ETCBC/bhsa/app</code></li><li><b>commit</b>: <i>no value</i></li><li><b>css</b>: <code>''</code></li><li><details><summary><b>dataDisplay</b>:</summary><ul><li><details><summary><b>exampleSectionHtml</b>:</summary><code>&lt;code>Genesis 1:1&lt;/code> (use &lt;a href=\"https://github.com/{org}/{repo}/blob/master/tf/{version}/book%40en.tf\" target=\"_blank\">English book names&lt;/a>)</code></details></li><li><details><summary><b>excludedFeatures</b>:</summary><ul><li><code>g_uvf_utf8</code></li><li><code>g_vbs</code></li><li><code>kq_hybrid</code></li><li><code>languageISO</code></li><li><code>g_nme</code></li><li><code>lex0</code></li><li><code>is_root</code></li><li><code>g_vbs_utf8</code></li><li><code>g_uvf</code></li><li><code>dist</code></li><li><code>root</code></li><li><code>suffix_person</code></li><li><code>g_vbe</code></li><li><code>dist_unit</code></li><li><code>suffix_number</code></li><li><code>distributional_parent</code></li><li><code>kq_hybrid_utf8</code></li><li><code>crossrefSET</code></li><li><code>instruction</code></li><li><code>g_prs</code></li><li><code>lexeme_count</code></li><li><code>rank_occ</code></li><li><code>g_pfm_utf8</code></li><li><code>freq_occ</code></li><li><code>crossrefLCS</code></li><li><code>functional_parent</code></li><li><code>g_pfm</code></li><li><code>g_nme_utf8</code></li><li><code>g_vbe_utf8</code></li><li><code>kind</code></li><li><code>g_prs_utf8</code></li><li><code>suffix_gender</code></li><li><code>mother_object_type</code></li></ul></details></li><li><details><summary><b>noneValues</b>:</summary><ul><li><code>absent</code></li><li><code>n/a</code></li><li><code>none</code></li><li><code>unknown</code></li><li><i>no value</i></li><li><code>NA</code></li></ul></details></li></ul></details></li><li><details><summary><b>docs</b>:</summary><ul><li><b>docBase</b>: <code>{docRoot}/{repo}</code></li><li><b>docExt</b>: <code>''</code></li><li><b>docPage</b>: <code>''</code></li><li><b>docRoot</b>: <code>https://{org}.github.io</code></li><li><b>featurePage</b>: <code>0_home</code></li></ul></details></li><li><b>interfaceDefaults</b>: <code>{}</code></li><li><b>isCompatible</b>: <code>True</code></li><li><b>local</b>: <code>clone</code></li><li><b>localDir</b>: <code>/home/proycon/github/ETCBC/bhsa/_temp</code></li><li><details><summary><b>provenanceSpec</b>:</summary><ul><li><b>corpus</b>: <code>BHSA = Biblia Hebraica Stuttgartensia Amstelodamensis</code></li><li><b>doi</b>: <code>10.5281/zenodo.1007624</code></li><li><details><summary><b>moduleSpecs</b>:</summary><ul><li><details><summary>:</summary><ul><li><b>backend</b>: <i>no value</i></li><li><b>corpus</b>: <code>Phonetic Transcriptions</code></li><li><details><summary><b>docUrl</b>:</summary><code>https://nbviewer.jupyter.org/github/etcbc/phono/blob/master/programs/phono.ipynb</code></details></li><li><b>doi</b>: <code>10.5281/zenodo.1007636</code></li><li><b>org</b>: <code>ETCBC</code></li><li><b>relative</b>: <code>/tf</code></li><li><b>repo</b>: <code>phono</code></li></ul></details></li><li><details><summary>:</summary><ul><li><b>backend</b>: <i>no value</i></li><li><b>corpus</b>: <code>Parallel Passages</code></li><li><details><summary><b>docUrl</b>:</summary><code>https://nbviewer.jupyter.org/github/ETCBC/parallels/blob/master/programs/parallels.ipynb</code></details></li><li><b>doi</b>: <code>10.5281/zenodo.1007642</code></li><li><b>org</b>: <code>ETCBC</code></li><li><b>relative</b>: <code>/tf</code></li><li><b>repo</b>: <code>parallels</code></li></ul></details></li></ul></details></li><li><b>org</b>: <code>ETCBC</code></li><li><b>relative</b>: <code>/tf</code></li><li><b>repo</b>: <code>bhsa</code></li><li><b>version</b>: <code>2021</code></li><li><b>webBase</b>: <code>https://shebanq.ancient-data.org/hebrew</code></li><li><b>webHint</b>: <code>Show this on SHEBANQ</code></li><li><b>webLang</b>: <code>la</code></li><li><b>webLexId</b>: <code>True</code></li><li><details><summary><b>webUrl</b>:</summary><code>{webBase}/text?book=&lt;1>&amp;chapter=&lt;2>&amp;verse=&lt;3>&amp;version={version}&amp;mr=m&amp;qw=q&amp;tp=txt_p&amp;tr=hb&amp;wget=v&amp;qget=v&amp;nget=vt</code></details></li><li><b>webUrlLex</b>: <code>{webBase}/word?version={version}&amp;id=&lt;lid></code></li></ul></details></li><li><b>release</b>: <i>no value</i></li><li><details><summary><b>typeDisplay</b>:</summary><ul><li><details><summary><b>clause</b>:</summary><ul><li><b>label</b>: <code>{typ} {rela}</code></li><li><b>style</b>: <code>''</code></li></ul></details></li><li><details><summary><b>clause_atom</b>:</summary><ul><li><b>hidden</b>: <code>True</code></li><li><b>label</b>: <code>{code}</code></li><li><b>level</b>: <code>1</code></li><li><b>style</b>: <code>''</code></li></ul></details></li><li><details><summary><b>half_verse</b>:</summary><ul><li><b>hidden</b>: <code>True</code></li><li><b>label</b>: <code>{label}</code></li><li><b>style</b>: <code>''</code></li><li><b>verselike</b>: <code>True</code></li></ul></details></li><li><details><summary><b>lex</b>:</summary><ul><li><b>featuresBare</b>: <code>gloss</code></li><li><b>label</b>: <code>{voc_lex_utf8}</code></li><li><b>lexOcc</b>: <code>word</code></li><li><b>style</b>: <code>orig</code></li><li><b>template</b>: <code>{voc_lex_utf8}</code></li></ul></details></li><li><details><summary><b>phrase</b>:</summary><ul><li><b>label</b>: <code>{typ} {function}</code></li><li><b>style</b>: <code>''</code></li></ul></details></li><li><details><summary><b>phrase_atom</b>:</summary><ul><li><b>hidden</b>: <code>True</code></li><li><b>label</b>: <code>{typ} {rela}</code></li><li><b>level</b>: <code>1</code></li><li><b>style</b>: <code>''</code></li></ul></details></li><li><details><summary><b>sentence</b>:</summary><ul><li><b>label</b>: <code>{number}</code></li><li><b>style</b>: <code>''</code></li></ul></details></li><li><details><summary><b>sentence_atom</b>:</summary><ul><li><b>hidden</b>: <code>True</code></li><li><b>label</b>: <code>{number}</code></li><li><b>level</b>: <code>1</code></li><li><b>style</b>: <code>''</code></li></ul></details></li><li><details><summary><b>subphrase</b>:</summary><ul><li><b>hidden</b>: <code>True</code></li><li><b>label</b>: <code>{number}</code></li><li><b>style</b>: <code>''</code></li></ul></details></li><li><details><summary><b>word</b>:</summary><ul><li><b>features</b>: <code>pdp vs vt</code></li><li><b>featuresBare</b>: <code>lex:gloss</code></li></ul></details></li></ul></details></li><li><b>writing</b>: <code>hbo</code></li></ol></details>\n"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -1480,8 +1482,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current:  2.81 GB\n",
-      "Delta:    2.68 GB\n"
+      "Current:  2.77 GB\n",
+      "Delta:    2.65 GB\n"
      ]
     }
    ],
@@ -1499,15 +1501,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current:  2.93 GB\n",
-      "Delta:    0.11 GB\n"
+      "Current:  2.89 GB\n",
+      "Delta:    0.12 GB\n"
      ]
     }
    ],
@@ -1536,16 +1538,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.3.0\n"
+     ]
+    }
+   ],
    "source": [
-    "import stam"
+    "from stam import VERSION, AnnotationStore, Selector, Offset\n",
+    "print(VERSION)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -1568,8 +1579,8 @@
       "nodes (type phrase) ...\n",
       "nodes (type phrase_atom) ...\n",
       "nodes (type subphrase) ...\n",
-      "Current:  3.83 GB\n",
-      "Delta:    0.90 GB\n"
+      "Current:  3.54 GB\n",
+      "Delta:    0.64 GB\n"
      ]
     }
    ],
@@ -1577,9 +1588,9 @@
     "storeId = \"ETCBC/bhsa\"\n",
     "print(f\"store (corpus {storeId}) ...\")\n",
     "\n",
-    "store = stam.AnnotationStore(id=storeId)\n",
+    "store = AnnotationStore(id=storeId)\n",
     "setId = \"features\"\n",
-    "dataset = store.add_annotationset(setId)\n",
+    "dataset = store.add_dataset(setId)\n",
     "\n",
     "textId = \"hebrew_unicode\"\n",
     "print(f\"text (format {textId}) ...\")\n",
@@ -1587,16 +1598,9 @@
     "\n",
     "print(\"nodes\")\n",
     "\n",
-    "stamTextSel = stam.Selector.textselector\n",
-    "stamOffset = stam.Offset.simple\n",
-    "stamCompSel = stam.Selector.compositeselector\n",
-    "stamAnnoSel = stam.Selector.annotationselector\n",
-    "storeAnnotate = store.annotate\n",
-    "storeAnno = store.annotation\n",
-    "\n",
     "otypeKey = dataset.add_key(\"otype\")\n",
     "\n",
-    "annoIdFromNode = {}\n",
+    "annoFromNode = {}\n",
     "\n",
     "slotType = F.otype.slotType\n",
     "\n",
@@ -1606,10 +1610,9 @@
     "\n",
     "for w in F.otype.s(otype):\n",
     "    typeData = dict(key=otypeKey, value=otype, set=dataset)\n",
-    "    anno = storeAnnotate(\n",
-    "        target=stamTextSel(textResource, stamOffset(*pos[w])), data=typeData\n",
+    "    annoFromNode[w] = store.annotate(\n",
+    "        target=Selector.textselector(textResource, Offset.simple(*pos[w])), data=typeData\n",
     "    )\n",
-    "    annoIdFromNode[w] = anno.id()\n",
     "\n",
     "for otype in F.otype.all:\n",
     "    if otype == F.otype.slotType:\n",
@@ -1618,18 +1621,17 @@
     "    typeData = dict(key=otypeKey, value=otype, set=dataset)\n",
     "    for n in F.otype.s(otype):\n",
     "        slots = E.oslots.s(n)\n",
-    "        slotsSel = stamCompSel(\n",
-    "            *[stamAnnoSel(storeAnno(annoIdFromNode[slot])) for slot in slots]\n",
+    "        slotsSel = Selector.compositeselector(\n",
+    "            *[Selector.annotationselector(annoFromNode[slot]) for slot in slots]\n",
     "        )\n",
-    "        anno = store.annotate(target=slotsSel, data=typeData)\n",
-    "        annoIdFromNode[n] = anno.id()\n",
+    "        annoFromNode[n] = store.annotate(target=slotsSel, data=typeData)\n",
     "\n",
     "memUsage()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -1718,8 +1720,8 @@
       "\tvoc_lex_utf8\n",
       "\tvs\n",
       "\tvt\n",
-      "Current:  7.55 GB\n",
-      "Delta:    3.73 GB\n"
+      "Current:  6.05 GB\n",
+      "Delta:    2.51 GB\n"
      ]
     }
    ],
@@ -1733,7 +1735,43 @@
     "    featKey = dataset.add_key(feat)\n",
     "    for (n, v) in Fs(feat).items():\n",
     "        featData = dict(key=featKey, value=v, set=dataset)\n",
-    "        storeAnnotate(target=stamAnnoSel(storeAnno(annoIdFromNode[n])), data=featData)\n",
+    "        store.annotate(target=Selector.annotationselector(annoFromNode[n]), data=featData)\n",
+    "\n",
+    "memUsage()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "edge features\n",
+      "\tcrossref\n",
+      "\tmother\n",
+      "Current:  6.09 GB\n",
+      "Delta:    0.04 GB\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"edge features\")\n",
+    "\n",
+    "for feat in Eall():\n",
+    "    if feat == \"oslots\":\n",
+    "        continue\n",
+    "    print(f\"\\t{feat}\")\n",
+    "    featKey = dataset.add_key(feat)\n",
+    "    nId = Selector.annotationselector(annoFromNode[n])\n",
+    "    for n, ms in Es(feat).items():\n",
+    "        for m, v in ms.items() if type(ms) is dict else ((x, None) for x in ms):\n",
+    "            featData = dict(key=featKey, value=v, set=dataset)\n",
+    "            mId = Selector.annotationselector(annoFromNode[m])\n",
+    "            target = Selector.compositeselector(nId, mId)\n",
+    "            store.annotate(target=target, data=featData)\n",
     "\n",
     "memUsage()"
    ]
@@ -1747,31 +1785,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "edge features\n",
-      "\tcrossref\n",
-      "\tmother\n",
-      "Current:  7.77 GB\n",
-      "Delta:    0.21 GB\n"
+      "cleanup - deallocating python overhead from conversion\n",
+      "Current:  5.85 GB\n",
+      "Delta:   -0.24 GB\n",
+      "cleanup - optimizing memory consumption of internal STAM data structures\n",
+      "Current:  5.85 GB\n",
+      "Delta:   -0.00 GB\n",
+      "(note: textfabric model is still loaded as well!)\n"
      ]
     }
    ],
    "source": [
-    "print(\"edge features\")\n",
+    "print(\"cleanup - deallocating python overhead from conversion\")\n",
     "\n",
-    "for feat in Eall():\n",
-    "    if feat == \"oslots\":\n",
-    "        continue\n",
-    "    print(f\"\\t{feat}\")\n",
-    "    featKey = dataset.add_key(feat)\n",
-    "    nId = stamAnnoSel(storeAnno(annoIdFromNode[n]))\n",
-    "    for n, ms in Es(feat).items():\n",
-    "        for m, v in ms.items() if type(ms) is dict else ((x, None) for x in ms):\n",
-    "            featData = dict(key=featKey, value=v, set=dataset)\n",
-    "            mId = stamAnnoSel(storeAnno(annoIdFromNode[m]))\n",
-    "            target = stamCompSel(nId, mId)\n",
-    "            storeAnnotate(target=target, data=featData)\n",
+    "del annoFromNode, text, pos\n",
+    "memUsage()\n",
     "\n",
-    "memUsage()"
+    "print(\"cleanup - optimizing memory consumption of internal STAM data structures\")\n",
+    "store.shrink_to_fit()\n",
+    "memUsage()\n",
+    "\n",
+    "print(\"(note: textfabric model is still loaded as well!)\")\n"
    ]
   },
   {
@@ -1780,7 +1814,7 @@
    "source": [
     "# Serializing\n",
     "\n",
-    "Lets serialize the STAM dataset to disk, in JSON and CSV."
+    "Let's serialize the STAM dataset to disk, in JSON and CSV."
    ]
   },
   {
@@ -1809,8 +1843,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current:  9.17 GB\n",
-      "Delta:    1.40 GB\n"
+      "Current:  5.85 GB\n",
+      "Delta:    0.00 GB\n"
      ]
     }
    ],
@@ -1829,15 +1863,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current:  9.17 GB\n",
-      "Delta:    0.00 GB\n"
+      "Current:  5.90 GB\n",
+      "Delta:    0.05 GB\n"
      ]
     }
    ],
@@ -1876,8 +1910,8 @@
      "text": [
       "Current:  0.07 GB\n",
       "Delta:    0.07 GB\n",
-      "Current: 16.41 GB\n",
-      "Delta:   16.34 GB\n"
+      "Current:  3.12 GB\n",
+      "Delta:    3.05 GB\n"
      ]
     }
    ],
@@ -1889,7 +1923,7 @@
     "memUsage()\n",
     "\n",
     "workDir = os.path.expanduser(\"~/github/ETCBC/bhsa/_temp/stam\")\n",
-    "storeJ = stam.AnnotationStore(file=f\"{workDir}/bhsa.json\")\n",
+    "store = stam.AnnotationStore(file=f\"{workDir}/bhsa.json\")\n",
     "memUsage()"
    ]
   },
@@ -1904,17 +1938,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current:  0.07 GB\n",
-      "Delta:    0.07 GB\n",
-      "Current: 16.66 GB\n",
-      "Delta:   16.60 GB\n"
+      "Current:  3.12 GB\n",
+      "Delta:    0.00 GB\n",
+      "Current:  4.42 GB\n",
+      "Delta:    1.29 GB\n"
      ]
     }
    ],
@@ -1926,7 +1960,7 @@
     "memUsage()\n",
     "\n",
     "workDir = os.path.expanduser(\"~/github/ETCBC/bhsa/_temp/stam\")\n",
-    "storeC = stam.AnnotationStore(file=f\"{workDir}/bhsa.store.stam.csv\")\n",
+    "store = stam.AnnotationStore(file=f\"{workDir}/bhsa.store.stam.csv\")\n",
     "memUsage()"
    ]
   },
@@ -1938,9 +1972,9 @@
     "\n",
     "contender | load time (sec) | save time (sec) | mem usage (GB) | disk usage (GB)\n",
     "--- | --- | --- | --- | ---\n",
-    "STAM | | | 16.4 | \n",
-    "STAM-JSON | 115 | 17 | | 8.15\n",
-    "STAM-CSV | 53 | 7 | | 2.35\n",
+    "STAM | | | 3.05 | \n",
+    "STAM-JSON | ? | ? | | 6.8\n",
+    "STAM-CSV | ? | ? | | 1.2\n",
     "TF | | | 2.7 |\n",
     "TF text | 92 | | | 0.10\n",
     "TF opt | 3 | | | 0.14\n",
@@ -2066,9 +2100,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "bhsa-env",
    "language": "python",
-   "name": "python3"
+   "name": "bhsa-env"
   },
   "language_info": {
    "codemirror_mode": {
@@ -2080,10 +2114,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
-  },
-  "orig_nbformat": 4
+   "version": "3.11.3"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This version relies on the latest git version of stam-python (and stam-rust), both have not been released yet.

I adapted the code to work without IDs, besides that there are no other functional changes to the modelling.

I also removed aliases as they were confusing me.

I might amend this PR with some more commits later (so no rush to merge).